### PR TITLE
fix flake8 issues

### DIFF
--- a/ga4gh/_protocol_definitions.py
+++ b/ga4gh/_protocol_definitions.py
@@ -345,8 +345,9 @@ Read characterization data.
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
-    __slots__ = ['analysisId', 'complexity', 'exonicFraction', 'fractionMapped',
-                 'intergenicFraction', 'intronicFraction']
+    __slots__ = [
+        'analysisId', 'complexity', 'exonicFraction', 'fractionMapped',
+        'intergenicFraction', 'intronicFraction']
 
     def __init__(self):
         self.analysisId = None
@@ -3177,8 +3178,9 @@ as JSON.
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
-    __slots__ = ['expressionLevelId', 'featureGroupId', 'pageSize', 'pageToken',
-                 'rnaQuantificationId']
+    __slots__ = [
+        'expressionLevelId', 'featureGroupId', 'pageSize', 'pageToken',
+        'rnaQuantificationId']
 
     def __init__(self):
         self.expressionLevelId = None
@@ -3347,7 +3349,7 @@ postMethods = \
      ('/variantsets/search',
       SearchVariantSetsRequest,
       SearchVariantSetsResponse),
-      ('/expressionlevel/search',
+     ('/expressionlevel/search',
       SearchExpressionLevelRequest,
       SearchExpressionLevelResponse),
      ('/rnaquantification/search',

--- a/ga4gh/backend.py
+++ b/ga4gh/backend.py
@@ -413,14 +413,15 @@ class AbstractBackend(object):
 
     def rnaQuantificationGenerator(self, request):
         """
-        Returns a generator over the (rnaQuantification, nextPageToken) pairs defined
-        by the specified request.
+        Returns a generator over the (rnaQuantification, nextPageToken) pairs
+        defined by the specified request.
         """
         rnaQuantificationId = request.rnaQuantificationId
         try:
             rnaQuant = self._rnaQuantificationIdMap[rnaQuantificationId]
         except KeyError:
-            raise exceptions.RnaQuantificationNotFoundException(rnaQuantificationId)
+            raise exceptions.RnaQuantificationNotFoundException(
+                rnaQuantificationId)
         currentIndex = 0
         if request.pageToken is not None:
             currentIndex, = _parsePageToken(request.pageToken, 1)
@@ -454,9 +455,11 @@ class AbstractBackend(object):
             rnaQuantificationIds = self._rnaQuantificationIds
         for rnaQuantId in rnaQuantificationIds:
             rnaQuant = self._rnaQuantificationIdMap[rnaQuantId]
-            expressionLevelIterator = rnaQuant.getExpressionLevel(expressionLevelId, featureGroupId)
+            expressionLevelIterator = rnaQuant.getExpressionLevel(
+                expressionLevelId, featureGroupId)
             expressionLevelData = next(expressionLevelIterator, None)
-            while expressionLevelData is not None and currentIndex < self._defaultPageSize:
+            while (expressionLevelData is not None and
+                    currentIndex < self._defaultPageSize):
                 nextExpressionLevelData = next(expressionLevelIterator, None)
                 nextPageToken = None
                 if nextExpressionLevelData is not None:
@@ -465,7 +468,8 @@ class AbstractBackend(object):
                 expressionLevel = protocol.ExpressionLevel()
                 expressionLevel.annotationId = expressionLevelData.annotationId
                 expressionLevel.expression = expressionLevelData.expression
-                expressionLevel.featureGroupId = expressionLevelData.featureGroupId
+                expressionLevel.featureGroupId = (
+                    expressionLevelData.featureGroupId)
                 expressionLevel.id = expressionLevelData.id
                 expressionLevel.isNormalized = expressionLevelData.isNormalized
                 expressionLevel.rawReadCount = expressionLevelData.rawReadCount
@@ -609,7 +613,7 @@ class FileSystemBackend(AbstractBackend):
         self._readGroupSetIds = sorted(self._readGroupSetIdMap.keys())
         self._readGroupIds = sorted(self._readGroupIdMap.keys())
 
-        #Rna Quantification
+        # Rna Quantification
         rnaQuantDir = os.path.join(self._dataDir, "rnaQuant")
         for rnaQuantId in os.listdir(rnaQuantDir):
             relativePath = os.path.join(rnaQuantDir, rnaQuantId)
@@ -617,5 +621,5 @@ class FileSystemBackend(AbstractBackend):
                 rnaQuantification = rna_quantification.RNASeqResult(
                     rnaQuantId, relativePath)
                 self._rnaQuantificationIdMap[rnaQuantId] = rnaQuantification
-        self._rnaQuantificationIds = sorted(self._rnaQuantificationIdMap.keys())
-
+        self._rnaQuantificationIds = sorted(
+            self._rnaQuantificationIdMap.keys())

--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -130,19 +130,20 @@ class RequestFactory(object):
 
     def createSearchRnaQuantificationRequest(self):
         request = protocol.SearchRnaQuantificationRequest()
-        #allow only a single ID for now
-        #setCommaSeparatedAttribute(request, self.args, 'rnaQuantificationId')
+        # allow only a single ID for now
+        # setCommaSeparatedAttribute(request, self.args, 'rnaQuantificationId')
         request.rnaQuantificationId = self.args.rnaQuantificationId
         return request
 
     def createSearchExpressionLevelRequest(self):
         request = protocol.SearchExpressionLevelRequest()
-        #allow only a single ID for now
-        #setCommaSeparatedAttribute(request, self.args, 'expressionLevelId')
+        # allow only a single ID for now
+        # setCommaSeparatedAttribute(request, self.args, 'expressionLevelId')
         request.expressionLevelId = self.args.expressionLevelId
         request.featureGroupId = self.args.featureGroupId
         request.rnaQuantificationId = self.args.rnaQuantificationId
         return request
+
 
 def getWorkarounds(args):
     if args.workarounds is None:

--- a/ga4gh/client.py
+++ b/ga4gh/client.py
@@ -268,4 +268,3 @@ class HttpClient(object):
         return self.runSearchRequest(
             protocolRequest, "expressionlevel",
             protocol.SearchExpressionLevelResponse)
-

--- a/ga4gh/datamodel/rna_quantification.py
+++ b/ga4gh/datamodel/rna_quantification.py
@@ -10,22 +10,28 @@ import os
 
 import ga4gh.protocol as protocol
 
+
 """
-TODO: Would be nice to just use the csv module to read inputs and have headers in files for clarity
-      and to eliminate the whole record[N] absurdity.
-      
-      Additionally, characterization and read counts doesn't have an access point.
+TODO: Would be nice to just use the csv module to read inputs and have headers
+in files for clarity and to eliminate the whole record[N] absurdity.
+
+Additionally, characterization and read counts doesn't have an access point.
 """
+
+
 class RNASeqResult(object):
     """
     Class representing a single RnaQuantification in the GA4GH data model.
     """
     def __init__(self, rnaQuantificationId, rnaQuantDataPath):
         self._rnaQuantificationId = rnaQuantificationId
-        self._rnaQuantificationFile = os.path.join(rnaQuantDataPath, "rnaseq.table")
-        self._characterizationFile = os.path.join(rnaQuantDataPath, "dist.table")
+        self._rnaQuantificationFile = os.path.join(
+            rnaQuantDataPath, "rnaseq.table")
+        self._characterizationFile = os.path.join(
+            rnaQuantDataPath, "dist.table")
         self._readCountFile = os.path.join(rnaQuantDataPath, "counts.table")
-        self._expressionLevelFile = os.path.join(rnaQuantDataPath, "expression.table")
+        self._expressionLevelFile = os.path.join(
+            rnaQuantDataPath, "expression.table")
 
     def convertCharacterization(self, record):
         readCharacterization = protocol.Characterization
@@ -41,12 +47,13 @@ class RNASeqResult(object):
     def getCharacterization(self, rnaQuantificationId):
         """
         input is tab file with no header.  Columns are:
-        analysisId, complexity, exonicFraction, fractionMapped, intergenicFraction, intronicFraction
+        analysisId, complexity, exonicFraction, fractionMapped,
+        intergenicFraction, intronicFraction
         """
         characterizationData = open(self._characterizationFile, "r")
         quantCharacterization = characterizationData.readline()
         fields = quantCharacterization.split('/t')
-        if rnaQuantificationID is None or fields[0] == rnaQuantificationId:
+        if rnaQuantificationId is None or fields[0] == rnaQuantificationId:
             yield self.convertCharacterization(fields)
 
     def convertReadCounts(self, record):
@@ -63,12 +70,13 @@ class RNASeqResult(object):
     def getReadCounts(self, rnaQuantificationId):
         """
         input is tab file with no header.  Columns are:
-        analysisId, multiCount, multiSpliceCount, totalReadCount, uniqueCount, uniqueSpliceCount
+        analysisId, multiCount, multiSpliceCount, totalReadCount, uniqueCount,
+        uniqueSpliceCount
         """
         readCountData = open(self._readCountFile, "r")
         countData = readCountData.readline()
         fields = countData.split('/t')
-        if rnaQuantificationID is None or fields[0] == rnaQuantificationId:
+        if rnaQuantificationId is None or fields[0] == rnaQuantificationId:
             yield self.convertReadCounts(fields)
 
     def convertRnaQuantification(self, record):
@@ -111,8 +119,9 @@ class RNASeqResult(object):
         input is tab file with no header.  Columns are:
         id, annotationId, expression, featureGroupId,
         isNormalized, rawReadCount, score, units
-        
-        expressionLevelId is not None: return only the specific expressionLevel object
+
+        expressionLevelId is not None: return only the specific expressionLevel
+        object
         featureGroupId is not None: return all in that group
         """
         expressionLevelData = open(self._expressionLevelFile, "r")
@@ -120,10 +129,12 @@ class RNASeqResult(object):
             fields = expressionData.strip().split('\t')
             if featureGroupId is not None:
                 if fields[3] == featureGroupId:
-                    if expressionLevelId is None or fields[0] == expressionLevelId:
+                    if (expressionLevelId is None or fields[0] ==
+                            expressionLevelId):
                         yield self.convertExpressionLevel(fields)
             elif expressionLevelId is None or fields[0] == expressionLevelId:
                 yield self.convertExpressionLevel(fields)
+
 
 class SimulatedRNASeqResult(object):
     """
@@ -144,12 +155,13 @@ class SimulatedRNASeqResult(object):
     def getCharacterization(self, rnaQuantificationId):
         """
         input is tab file with no header.  Columns are:
-        analysisId, complexity, exonicFraction, fractionMapped, intergenicFraction, intronicFraction
+        analysisId, complexity, exonicFraction, fractionMapped,
+        intergenicFraction, intronicFraction
         """
         characterizationData = open(self._characterizationFile, "r")
         quantCharacterization = characterizationData.readline()
         fields = quantCharacterization.split('/t')
-        if rnaQuantificationID is None or fields[0] == rnaQuantificationId:
+        if rnaQuantificationId is None or fields[0] == rnaQuantificationId:
             yield self.generateCharacterization()
 
     def generateReadCounts(self):
@@ -163,12 +175,13 @@ class SimulatedRNASeqResult(object):
     def getReadCounts(self, rnaQuantificationId):
         """
         input is tab file with no header.  Columns are:
-        analysisId, multiCount, multiSpliceCount, totalReadCount, uniqueCount, uniqueSpliceCount
+        analysisId, multiCount, multiSpliceCount, totalReadCount, uniqueCount,
+        uniqueSpliceCount
         """
         readCountData = open(self._readCountFile, "r")
         countData = readCountData.readline()
         fields = countData.split('/t')
-        if rnaQuantificationID is None or fields[0] == rnaQuantificationId:
+        if rnaQuantificationId is None or fields[0] == rnaQuantificationId:
             yield self.generateReadCounts()
 
     def generateRnaQuantification(self):
@@ -205,7 +218,8 @@ class SimulatedRNASeqResult(object):
         annotationId, expression, featureGroupId, id,
         isNormalized, rawReadCount, score, units
 
-        expressionLevelId is not None: return only the specific expressionLevel object
+        expressionLevelId is not None: return only the specific expressionLevel
+        object
         featureGroupId is not None: return all in that group
         """
         expressionLevelData = open(self._expressionLevelFile, "r")
@@ -213,7 +227,8 @@ class SimulatedRNASeqResult(object):
             fields = expressionData.strip().split('\t')
             if featureGroupId is not None:
                 if fields[3] == featureGroupId:
-                    if expressionLevelId is None or fields[0] == expressionLevelId:
+                    if (expressionLevelId is None or
+                            fields[0] == expressionLevelId):
                         yield self.generateExpressionLevel(fields)
             elif expressionLevelId is None or fields[0] == expressionLevelId:
                 yield self.generateExpressionLevel(fields)

--- a/ga4gh/exceptions.py
+++ b/ga4gh/exceptions.py
@@ -170,8 +170,9 @@ class ReadGroupNotFoundException(ObjectNotFoundException):
 
 class RnaQuantificationNotFound(NotFoundException):
     def __init__(self, rnaQuantificationId):
-        self.message = "The requested RnaQuantification '{}' was not found".format(
-            rnaQuantificationId)
+        self.message = (
+            "The requested RnaQuantification '{}' was not found".format(
+                rnaQuantificationId))
 
 
 class UnsupportedMediaTypeException(RuntimeException):

--- a/scripts/process_schemas.py
+++ b/scripts/process_schemas.py
@@ -424,8 +424,9 @@ def main():
     # TODO is this the right approach? Maybe we should be noisy be
     # default and add in an option to be quiet.
     parser.add_argument('--verbose', '-v', action='count', default=0)
-    parser.add_argument('--local_avdl', help="The path to local avdl tarball",
-        default=None)
+    parser.add_argument(
+            '--local_avdl', help="The path to local avdl tarball",
+            default=None)
     # We don't support Python 3 right now because the Avro API is
     # different between the different versions.
     if sys.version_info >= (3, 0):

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -160,6 +160,7 @@ class ImportGraphLayerChecker(object):
         'exceptions': ['ga4gh/exceptions.py'],
         'datamodel': ['ga4gh/datamodel/reads.py',
                       'ga4gh/datamodel/references.py',
+                      'ga4gh/datamodel/rna_quantification.py',
                       'ga4gh/datamodel/variants.py'],
         'libraries': ['ga4gh/converters.py', 'ga4gh/avrotools.py'],
         'protocol': ['ga4gh/protocol.py', 'ga4gh/_protocol_definitions.py'],


### PR DESCRIPTION
Hi Sean,

The only one I'm concerned about is [rnaQuantificationID vs rnaQuantificationId](https://github.com/saupchurch/server/compare/master...UMMS-Biocore:2015-04-29_rna_flake8?expand=1#diff-2f8875ecb929aea53c6a6998375e12b8L71). Occurs in several places, please confirm this fix is correct?

Otherwise, this fixes a number of issues against PEP8 in travis-ci
[Original](https://travis-ci.org/UMMS-Biocore/server/builds/60566739)
[flake8 passing](https://travis-ci.org/UMMS-Biocore/server/builds/60582246)

1.47s$ flake8 *.py tests ga4gh scripts --exclude=ez_setup.py
ga4gh/client.py:271:1: W391 blank line at end of file
ga4gh/exceptions.py:173:80: E501 line too long (83 > 79 characters)
ga4gh/datamodel/rna_quantification.py:14:80: E501 line too long (99 > 79 characters)
ga4gh/datamodel/rna_quantification.py:16:1: W293 blank line contains whitespace
ga4gh/datamodel/rna_quantification.py:17:80: E501 line too long (82 > 79 characters)
ga4gh/datamodel/rna_quantification.py:19:1: E302 expected 2 blank lines, found 0
ga4gh/datamodel/rna_quantification.py:25:80: E501 line too long (84 > 79 characters)
ga4gh/datamodel/rna_quantification.py:26:80: E501 line too long (81 > 79 characters)
ga4gh/datamodel/rna_quantification.py:28:80: E501 line too long (86 > 79 characters)
ga4gh/datamodel/rna_quantification.py:44:80: E501 line too long (100 > 79 characters)
ga4gh/datamodel/rna_quantification.py:49:12: F821 undefined name 'rnaQuantificationID'
ga4gh/datamodel/rna_quantification.py:66:80: E501 line too long (96 > 79 characters)
ga4gh/datamodel/rna_quantification.py:71:12: F821 undefined name 'rnaQuantificationID'
ga4gh/datamodel/rna_quantification.py:114:1: W293 blank line contains whitespace
ga4gh/datamodel/rna_quantification.py:115:80: E501 line too long (86 > 79 characters)
ga4gh/datamodel/rna_quantification.py:123:80: E501 line too long (83 > 79 characters)
ga4gh/datamodel/rna_quantification.py:128:1: E302 expected 2 blank lines, found 1
ga4gh/datamodel/rna_quantification.py:147:80: E501 line too long (100 > 79 characters)
ga4gh/datamodel/rna_quantification.py:152:12: F821 undefined name 'rnaQuantificationID'
ga4gh/datamodel/rna_quantification.py:166:80: E501 line too long (96 > 79 characters)
ga4gh/datamodel/rna_quantification.py:171:12: F821 undefined name 'rnaQuantificationID'
ga4gh/datamodel/rna_quantification.py:208:80: E501 line too long (86 > 79 characters)
ga4gh/datamodel/rna_quantification.py:216:80: E501 line too long (83 > 79 characters)
ga4gh/datamodel/rna_quantification.py:219:59: W292 no newline at end of file
scripts/process_schemas.py:456:9: E128 continuation line under-indented for visual indent
ga4gh/backend.py:416:80: E501 line too long (85 > 79 characters)
ga4gh/backend.py:423:80: E501 line too long (84 > 79 characters)
ga4gh/backend.py:457:80: E501 line too long (100 > 79 characters)
ga4gh/backend.py:459:80: E501 line too long (91 > 79 characters)
ga4gh/backend.py:468:80: E501 line too long (83 > 79 characters)
ga4gh/backend.py:612:9: E265 block comment should start with '# '
ga4gh/backend.py:620:80: E501 line too long (80 > 79 characters)
ga4gh/backend.py:621:1: W391 blank line at end of file
ga4gh/cli.py:133:9: E265 block comment should start with '# '
ga4gh/cli.py:134:9: E265 block comment should start with '# '
ga4gh/cli.py:140:9: E265 block comment should start with '# '
ga4gh/cli.py:141:9: E265 block comment should start with '# '
ga4gh/cli.py:147:1: E302 expected 2 blank lines, found 1
ga4gh/_protocol_definitions.py:348:80: E501 line too long (80 > 79 characters)
ga4gh/_protocol_definitions.py:3180:80: E501 line too long (80 > 79 characters)
ga4gh/_protocol_definitions.py:3350:7: E127 continuation line over-indented for visual indent
ga4gh/_protocol_definitions.py:3351:7: E128 continuation line under-indented for visual indent
ga4gh/_protocol_definitions.py:3352:7: E128 continuation line under-indented for visual indent
